### PR TITLE
Use babel's built-in jsx transform

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,8 +5,10 @@
       [
         "babelify",
         {
-          "jsxPragma":"h",
-          "plugins": ["babel-plugin-jsx-factory"]
+          "presets": [ "es2015" ],
+          "plugins": [
+            ["transform-react-jsx", {"pragma": "h"}]
+          ]
         }
       ]
     ]
@@ -17,8 +19,7 @@
     "watch": "watchify main.js -o public/bundle.js -dv"
   },
   "dependencies": {
-    "babel-plugin-jsx-factory": "^1.0.0",
-    "babelify": "^6.1.3",
+    "babelify": "^7.2.0",
     "browserify": "^10.2.6",
     "ecstatic": "~0.8.0",
     "main-loop": "^3.1.0",


### PR DESCRIPTION
Babel's packaged jsx transform accepts a `pragma` argument now.